### PR TITLE
fix(launch): Fix component launch issues

### DIFF
--- a/include/image_conversion.h
+++ b/include/image_conversion.h
@@ -18,7 +18,7 @@
 #include <opencv2/opencv.hpp>
 
 struct image_conversion {
-  static void nv12_to_bgr24_neon(uint8_t *nv12, uint8_t *bgr24, int width, int height);
+  static void nv12_to_bgr24_neon(const uint8_t *nv12, uint8_t *bgr24, int width, int height);
   static void bgr24_to_nv12_neon(uint8_t *bgr24, uint8_t *nv12, int width, int height);
   static void bgr_to_nv12(const cv::Mat &bgr, cv::Mat &nv12);
   static void nv12_to_bgr(const cv::Mat &nv12, cv::Mat &bgr);

--- a/include/stereonet_component.h
+++ b/include/stereonet_component.h
@@ -163,7 +163,8 @@ class StereoNetNode : public rclcpp::Node {
   int start();
   int stop();
 
-  void stereo_image_cb(const sensor_msgs::msg::Image::SharedPtr img);
+  // Subscriber ConstSharedPtr type msg to avoid memory copy
+  void stereo_image_cb(sensor_msgs::msg::Image::ConstSharedPtr img);
   void inference_by_usb_camera();
   void inference_by_image();
 

--- a/launch/stereonet_model_component.launch.py
+++ b/launch/stereonet_model_component.launch.py
@@ -113,6 +113,7 @@ def generate_launch_description():
                     plugin="stereonet::StereoNetNode",
                     name="StereoNetNode",
                     parameters=[set_configurable_parameters(node_params)],
+                    extra_arguments=[{"use_intra_process_comms": True}],
                 )
             ]
         )

--- a/launch/stereonet_model_web_visual.launch.py
+++ b/launch/stereonet_model_web_visual.launch.py
@@ -52,7 +52,7 @@ def generate_launch_description():
             )
         ),
         launch_arguments={
-            "mipi_frame_ts_type": "sensor",
+            # "mipi_frame_ts_type": "sensor", # default is sensor in mipi_cam launch
             "frame_id": "pcl_link",
             "log_level": "warn",
         }.items(),

--- a/launch/stereonet_model_web_visual_component.launch.py
+++ b/launch/stereonet_model_web_visual_component.launch.py
@@ -27,7 +27,9 @@ from launch.conditions import IfCondition
 from launch.conditions import UnlessCondition
 from launch.actions import DeclareLaunchArgument
 from launch.substitutions import LaunchConfiguration, PythonExpression
-
+from ament_index_python.packages import get_package_prefix
+from launch.substitutions import TextSubstitution
+import os
 
 def generate_launch_description():
     stereonet_pub_web_arg = DeclareLaunchArgument(
@@ -50,6 +52,11 @@ def generate_launch_description():
             )
         )
     )
+
+    config_file_path = os.path.join(
+        get_package_prefix('mipi_cam'),
+        "lib/mipi_cam/config/")
+    print("config_file_path is ", config_file_path)
 
     # 创建组件容器（关键步骤）
     container = ComposableNodeContainer(
@@ -76,18 +83,25 @@ def generate_launch_description():
         plugin="mipi_cam::MipiCamNode",
         name="mipi_cam_component",
         parameters=[
-            {"mipi_frame_ts_type": "sensor"},
-            {"frame_id": "pcl_link"},
-            {"device_mode": "dual"},
-            {"dual_combine": 1},
-            {"image_width": LaunchConfiguration("mipi_image_width")},
-            {"image_height": LaunchConfiguration("mipi_image_height")},
-            {"framerate": LaunchConfiguration("mipi_image_framerate")},
-            {"lpwm_enable": LaunchConfiguration("mipi_lpwm_enable")},
-            {"rotation": LaunchConfiguration("mipi_rotation")},
-            {"gdc_enable": LaunchConfiguration("mipi_gdc_enable")},
-            {"channel": 2},
-            {"channel2": 0},
+            {"config_path": LaunchConfiguration('mipi_config_path')},
+            {"camera_calibration_file_path": LaunchConfiguration(
+                'mipi_camera_calibration_file_path')},
+            {"out_format": LaunchConfiguration('mipi_out_format')},
+            {"image_width": LaunchConfiguration('mipi_image_width')},
+            {"image_height": LaunchConfiguration('mipi_image_height')},
+            {"framerate": LaunchConfiguration('mipi_image_framerate')},
+            {"io_method": LaunchConfiguration('mipi_io_method')},
+            {"video_device": LaunchConfiguration('mipi_video_device')},
+            {"device_mode": LaunchConfiguration('device_mode')},
+            {"gdc_bin_file": LaunchConfiguration('mipi_gdc_bin_file')},
+            {"dual_combine": LaunchConfiguration('dual_combine')},
+            {"lpwm_enable": LaunchConfiguration('mipi_lpwm_enable')},
+            {"channel": LaunchConfiguration('mipi_channel')},
+            {"channel2": LaunchConfiguration('mipi_channel2')},
+            {"frame_ts_type": LaunchConfiguration('mipi_frame_ts_type')},
+            {"rotation": LaunchConfiguration('mipi_rotation')},
+            {"gdc_enable": LaunchConfiguration('mipi_gdc_enable')},
+            {"frame_id": LaunchConfiguration('frame_id')},
         ],
         extra_arguments=[{"use_intra_process_comms": True}],
     )
@@ -142,6 +156,83 @@ def generate_launch_description():
 
     return LaunchDescription(
         [
+            DeclareLaunchArgument(
+                "mipi_config_path", 
+                default_value=TextSubstitution(text=str(config_file_path)),
+                description='mipi camera calibration file path'),
+            DeclareLaunchArgument(
+                'mipi_camera_calibration_file_path',
+                default_value=TextSubstitution(text=str(config_file_path)+"calib_params.yaml"),
+                description='mipi camera calibration file path'),
+            DeclareLaunchArgument(
+                'mipi_out_format',
+                default_value='nv12',
+                description='mipi camera out format'),
+            DeclareLaunchArgument(
+                'mipi_image_width',
+                default_value='1280',
+                description='mipi camera out image width'),
+            DeclareLaunchArgument(
+                'mipi_image_height',
+                default_value='720',
+                description='mipi camera out image height'),
+            DeclareLaunchArgument(
+                'mipi_image_framerate',
+                default_value='10.0',
+                description='mipi camera out image framerate'),
+            DeclareLaunchArgument(
+                'mipi_io_method',
+                default_value='ros',
+                description='mipi camera out io_method'),
+            DeclareLaunchArgument(
+                'mipi_video_device',
+                default_value='default',
+                description='mipi camera device'),
+            DeclareLaunchArgument(
+                'device_mode',
+                default_value='dual',
+                description='mipi camera device mode single or dual'),
+            DeclareLaunchArgument(
+                'dual_combine',
+                default_value='1',
+                description='dual mode output channel'),
+            DeclareLaunchArgument(
+                'mipi_channel',
+                default_value='2',
+                description='mipi camera host channel'),
+            DeclareLaunchArgument(
+                'mipi_channel2',
+                default_value='0',
+                description='mipi dual camera right channel'),
+            DeclareLaunchArgument(
+                'mipi_frame_ts_type',
+                default_value='sensor',
+                description='type(sensor/realtime) of timestamp for publishing messages'),
+            DeclareLaunchArgument(
+                'frame_id',
+                default_value='default_cam',
+                description=''),
+            DeclareLaunchArgument(
+                'mipi_gdc_bin_file',
+                default_value='',
+                description='mipi camera gdc bin_file'),
+            DeclareLaunchArgument(
+                'mipi_lpwm_enable',
+                default_value='False',
+                description='mipi dual camera lpwm enable'),
+            DeclareLaunchArgument(
+                'mipi_rotation',
+                default_value='0.0',
+                description='mipi camera out image rotation'),
+            DeclareLaunchArgument(
+                'mipi_gdc_enable',
+                default_value='True',
+                description='mipi camera gdc enable'),
+            DeclareLaunchArgument(
+                'log_level',
+                default_value='warn',
+                description='log level'),
+
             DeclareLaunchArgument(
                 "mipi_image_width",
                 default_value="640",

--- a/src/image_conversion.cpp
+++ b/src/image_conversion.cpp
@@ -16,7 +16,7 @@
 #include <cstdint>
 #include "image_conversion.h"
 
-void image_conversion::nv12_to_bgr24_neon(uint8_t *nv12, uint8_t *bgr24, int width, int height) {
+void image_conversion::nv12_to_bgr24_neon(const uint8_t *nv12, uint8_t *bgr24, int width, int height) {
   const uint8_t *yptr = nv12;
   const uint8_t *uvptr = nv12 + width * height;
   uint8x8_t _v128 = vdup_n_u8(128);

--- a/src/stereonet_component.cpp
+++ b/src/stereonet_component.cpp
@@ -81,15 +81,20 @@ int StereoNetNode::inference(inference_data_t &inference_data,
 
 int StereoNetNode::pub_depth_image(pub_data_t &pub_raw_data) {
   cv_bridge::CvImage img_bridge;
-  sensor_msgs::msg::Image depth_img_msg;
+  // Publish unique ptr to avoid memory copy
+  // Skip msg initialization to avoid extra time cost
+  auto depth_img_msg = std::make_unique<sensor_msgs::msg::Image>(
+      rosidl_runtime_cpp::MessageInitialization::SKIP
+    );
+
   const cv::Mat &depth_img = pub_raw_data.model_depth_img;
 
   if (depth_image_pub_->get_subscription_count() > 0) {
     img_bridge = cv_bridge::CvImage(pub_raw_data.left_sub_img.header,
                                     "mono16", depth_img);
-    img_bridge.toImageMsg(depth_img_msg);
-    depth_img_msg.header.frame_id = "camera_depth_frame";
-    depth_image_pub_->publish(depth_img_msg);
+    img_bridge.toImageMsg(*depth_img_msg);
+    depth_img_msg->header.frame_id = "camera_depth_frame";
+    depth_image_pub_->publish(std::move(depth_img_msg));
   }
 
   if (depthcompressed_image_pub_->get_subscription_count() > 0) {
@@ -620,9 +625,10 @@ int StereoNetNode::pub_pointcloud2(pub_data_t &pub_raw_data) {
                                   pub_raw_data.left_sub_img.bgr);
   }
   const cv::Mat &image = pub_raw_data.left_sub_img.bgr;
-  sensor_msgs::msg::PointCloud2 point_cloud_msg;
-  sensor_msgs::PointCloud2Modifier modifier(point_cloud_msg);
-
+  auto pcl_msg = std::make_unique<sensor_msgs::msg::PointCloud2>(
+      rosidl_runtime_cpp::MessageInitialization::SKIP
+    );
+  sensor_msgs::msg::PointCloud2& point_cloud_msg = *pcl_msg;
   point_cloud_msg.header = pub_raw_data.left_sub_img.header;
   point_cloud_msg.header.frame_id = "camera_link";
   point_cloud_msg.is_dense = false;
@@ -712,7 +718,7 @@ int StereoNetNode::pub_pointcloud2(pub_data_t &pub_raw_data) {
 //  }
   {
     ScopeProcessTime t("pcd publisher");
-    pointcloud2_pub_->publish(point_cloud_msg);
+    pointcloud2_pub_->publish(std::move(pcl_msg));
   }
   return 0;
 }
@@ -809,7 +815,7 @@ void save_images(cv::Mat &left_img, cv::Mat &right_img, uint64_t ts,
   //cv::imwrite("./images/cam_combine/data/combine_" + image_seq + "." + image_format, image_combine);
 }
 
-void StereoNetNode::stereo_image_cb(const sensor_msgs::msg::Image::SharedPtr img) {
+void StereoNetNode::stereo_image_cb(sensor_msgs::msg::Image::ConstSharedPtr img) {
   cv::Mat stereo_img, left_img, right_img;
   sub_image left_sub_img, right_sub_img;
   const std::string &encoding = img->encoding;


### PR DESCRIPTION
1. 测试数据
通信方式         进程间    进程内
delay(ms)        137         121
CPU(%)            154         112

注：此处进程内指的是使用ros2 composition功能将不同node load到同一个container中，即在一个进程内调度多个node达到进程内通信的效果。

2. 测试说明
  - 平台：X5 EVB, CPU 1.8G锁频，SC132GS双目相机，图像采集频率8fps。
  - delay统计：打开render_perf:=True配置统计深度估计delay。
  - CPU占用统计：watch -n 1 ps -aux --sort=-%cpu
  - 运行功能：双目图像采集、深度估计、图像编码、WEB可视化。

3. 启动命令说明
  - 进程间通信：
ros2 launch hobot_stereonet stereonet_model_web_visual_v2.1.launch.py             stereo_calib_file_path:=./calib_yg05/stereo_fish_yg05.yaml             mipi_image_width:=1280 mipi_image_height:=1088 mipi_rotation:=90.0 mipi_image_framerate:=8.0             render_type:=1 mipi_lpwm_enable:=True height_min:=-10.0 height_max:=10.0 pc_max_depth:=5.0             render_need_filter:=False render_type:=1 uncertainty_th:=0.05 need_pcl_filter:=False mipi_frame_ts_type:=realtime render_perf:=True
  - 进程内通信：
ros2 launch hobot_stereonet stereonet_model_web_visual_component_v2.1.launch.py             stereo_calib_file_path:=./calib_yg05/stereo_fish_yg05.yaml             mipi_image_width:=1280 mipi_image_height:=1088 mipi_rotation:=90.0 mipi_image_framerate:=8.0             render_type:=1 mipi_lpwm_enable:=True height_min:=-10.0 height_max:=10.0 pc_max_depth:=5.0             render_need_filter:=False render_type:=1 uncertainty_th:=0.05 need_pcl_filter:=False use_composition:=True mipi_frame_ts_type:=realtime render_perf:=True